### PR TITLE
Add dispatch async for main thread execution

### DIFF
--- a/ios/RNDynamicAppIcon.m
+++ b/ios/RNDynamicAppIcon.m
@@ -22,8 +22,10 @@ RCT_EXPORT_METHOD(setAppIcon:(NSString *)name)
 
 RCT_REMAP_METHOD(supportsDynamicAppIcon, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-  bool supported = [[UIApplication sharedApplication] supportsAlternateIcons];
-  resolve(@(supported));
+  dispatch_async(dispatch_get_main_queue(), ^{
+    bool supported = [[UIApplication sharedApplication] supportsAlternateIcons];
+    resolve(@(supported));
+  });
 }
 
 RCT_EXPORT_METHOD(getIconName:(RCTResponseSenderBlock) callback ){

--- a/ios/RNDynamicAppIcon.m
+++ b/ios/RNDynamicAppIcon.m
@@ -11,11 +11,13 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(setAppIcon:(NSString *)name)
 {
-  [[UIApplication sharedApplication] setAlternateIconName:name completionHandler:^(NSError * _Nullable error) {
-    if (error != nil) {
-      RCTLog(@"%@", [error description]);
-    }
-  }];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [[UIApplication sharedApplication] setAlternateIconName:name completionHandler:^(NSError * _Nullable error) {
+      if (error != nil) {
+        RCTLog(@"%@", [error description]);
+      }
+    }];
+  });
 }
 
 RCT_REMAP_METHOD(supportsDynamicAppIcon, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
@@ -25,6 +27,7 @@ RCT_REMAP_METHOD(supportsDynamicAppIcon, resolver:(RCTPromiseResolveBlock)resolv
 }
 
 RCT_EXPORT_METHOD(getIconName:(RCTResponseSenderBlock) callback ){
+  dispatch_async(dispatch_get_main_queue(), ^{
     NSString *name = @"default";
     NSDictionary *results;
     
@@ -41,6 +44,7 @@ RCT_EXPORT_METHOD(getIconName:(RCTResponseSenderBlock) callback ){
                 @"iconName":name
                 };
     callback(@[results]);
+  });
 }
 
 @end


### PR DESCRIPTION
This PR fixes UI hangs and app unresponsiveness when using the get/set/is available functions, by using the main thread for execution.

I was getting lengthy UI hangs and app unresponsiveness (usually lasting a few seconds) when attempting to get/set icons for my React Native app. There were also warnings in Xcode about not using the main thread. This PR fixes those warnings, and stops the lengthy UI hangs/unresponsiveness.